### PR TITLE
Python logo as SVG

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <a href="/"><img class="mb-4" src="https://www.python.org/static/community_logos/python-logo-master-v3-TM.png" alt="" height="72"></a>
+    <a href="/"><img class="mb-4" src="https://www.python.org/static/community_logos/python-logo-generic.svg" alt="Python Logo" height="72"></a>
 
     {% if gh_username and cla_result %}
         <h1 class="h3 mb-3 font-weight-normal"><a href="https://github.com/{{gh_username}}">{{ gh_username }}</a></h1>


### PR DESCRIPTION
This website does not have a white background, but current PNG logo has it.
So I changed it with SVG to get right transparency.
<img width="406" alt="screen shot 2018-09-01 at 6 58 03 pm" src="https://user-images.githubusercontent.com/579366/44944874-6ebb8a80-ae19-11e8-905c-da1b94a2383e.png">

----
Hi Mariatta,
I've come here by translating your interview on RealPython.
Thank you for the great interview!
