### PR TITLE
Update the wording surrounding PR label.

### DIFF
--- a/templates/pull_requests.html
+++ b/templates/pull_requests.html
@@ -5,7 +5,7 @@
 {% block content %}
     <a href="/"><img class="mb-4" src="https://www.python.org/static/community_logos/python-logo-master-v3-TM.png" alt="" height="72"></a>
     <h1 class="h3 mb-3 font-weight-normal"><a href="https://github.com/{{gh_username}}">{{ gh_username }}</a> has signed the CLA ✅</h1>
-    <p class="font-weight-normal">And we've updated these pull requests with <span class="badge badge-success">CLA signed</span> label.</p>
+    <p class="font-weight-normal">We will go through the following PRs and remove the <span class="badge badge-danger">CLA not signed</span> label.</p>
     <table class="table">
         <tbody>
             {% for pr in pull_requests %}


### PR DESCRIPTION
We're actually just removing the label, so the CLA can be rechecked.

Reword to make it clear that we're actually only removing the label.